### PR TITLE
Re-arrange email logging

### DIFF
--- a/compysition/actors/smtp.py
+++ b/compysition/actors/smtp.py
@@ -68,7 +68,7 @@ class SMTPOut(Actor):
             try:
                 self.send(msg, to, from_address)
             except Exception as err:
-                self.logger.error("Error sending message: {err}".format(err=traceback.format_exc()))
+                self.logger.error("Error sending message: {err}".format(err=traceback.format_exc()), event=event)
             else:
                 self.logger.info("Email sent to {to} from {from_address} via smtp server {host}".format(to=to,
                                                                                                         from_address=from_address,

--- a/compysition/actors/smtp.py
+++ b/compysition/actors/smtp.py
@@ -65,23 +65,23 @@ class SMTPOut(Actor):
                 if element.tag != self.body_tag:
                     msg[element.tag] = element.text
 
-            self.send(msg, to, from_address)
+            try:
+                self.send(msg, to, from_address)
+            except Exception as err:
+                self.logger.error("Error sending message: {err}".format(err=traceback.format_exc()))
+            else:
+                self.logger.info("Email sent to {to} from {from_address} via smtp server {host}".format(to=to,
+                                                                                                        from_address=from_address,
+                                                                                                        host=self.host))
         else:
             self.logger.info("No email recipient specified, notification was not sent", event=event)
 
         self.send_event(event)
 
     def send(self, msg, to, from_address):
-        try:
-            sender = smtplib.SMTP(self.host)
-            sender.sendmail(from_address, to.split(","), msg.as_string())
-            sender.quit()
-        except Exception as err:
-            self.logger.error("Error sending message: {err}".format(err=traceback.format_exc()))
-        else:
-            self.logger.info("Email sent to {to} from {from_address} via smtp server {host}".format(to=to,
-                                                                                                    from_address=from_address,
-                                                                                                    host=self.host))
+        sender = smtplib.SMTP(self.host)
+        sender.sendmail(from_address, to.split(","), msg.as_string())
+        sender.quit()
 
 
 class SMTPIn(Actor):

--- a/compysition/actors/smtp.py
+++ b/compysition/actors/smtp.py
@@ -66,9 +66,6 @@ class SMTPOut(Actor):
                     msg[element.tag] = element.text
 
             self.send(msg, to, from_address)
-            self.logger.info("Email sent to {to} from {from_address} via smtp server {host}".format(to=to,
-                                                                                                    from_address=from_address,
-                                                                                                    host=self.host), event=event)
         else:
             self.logger.info("No email recipient specified, notification was not sent", event=event)
 
@@ -81,6 +78,10 @@ class SMTPOut(Actor):
             sender.quit()
         except Exception as err:
             self.logger.error("Error sending message: {err}".format(err=traceback.format_exc()))
+        else:
+            self.logger.info("Email sent to {to} from {from_address} via smtp server {host}".format(to=to,
+                                                                                                    from_address=from_address,
+                                                                                                    host=self.host))
 
 
 class SMTPIn(Actor):

--- a/compysition/actors/smtp.py
+++ b/compysition/actors/smtp.py
@@ -72,7 +72,7 @@ class SMTPOut(Actor):
             else:
                 self.logger.info("Email sent to {to} from {from_address} via smtp server {host}".format(to=to,
                                                                                                         from_address=from_address,
-                                                                                                        host=self.host))
+                                                                                                        host=self.host), event=event)
         else:
             self.logger.info("No email recipient specified, notification was not sent", event=event)
 


### PR DESCRIPTION
The way the logs are currently arranged the line "Email sent to {to} from..." is logged even if there's an Exception in the `self.send` method.
