### PR TITLE
Change default HTTP event to HttpEvent

### DIFF
--- a/compysition/actors/httpserver.py
+++ b/compysition/actors/httpserver.py
@@ -130,7 +130,7 @@ class HTTPServer(Actor, Bottle):
                   ('application/xml', XMLHttpEvent),
                   ('application/json', JSONHttpEvent)]
     CONTENT_TYPES = [_type[0] for _type in _TYPES_MAP]
-    CONTENT_TYPE_MAP = defaultdict(lambda: JSONHttpEvent,
+    CONTENT_TYPE_MAP = defaultdict(lambda: HttpEvent,
                                    _TYPES_MAP)
 
     X_WWW_FORM_URLENCODED_KEY_MAP = defaultdict(lambda: HttpEvent, {"XML": XMLHttpEvent, "JSON": JSONHttpEvent})


### PR DESCRIPTION
@fiebiga This was previously HttpEvent, but was changed to JSONHttpEvent in [this commit](https://github.com/fiebiga/compysition/commit/ae645ec8bef9076bd916b0ff8e7e38b1238c1f40). Do you recall why that was changed?