### PR TITLE
Added customization to error events, including static and data extrac…

### DIFF
--- a/compysition/actors/__init__.py
+++ b/compysition/actors/__init__.py
@@ -39,9 +39,9 @@ from .mdpbroker import MDPBroker
 from .mdpregistrar import MDPBrokerRegistrationService
 from .eventlogger import EventLogger
 from .eventrouter import EventRouter, EventXMLFilter, EventFilter, HTTPMethodEventRouter, EventJSONFilter, EventXMLXpathsFilter, SimpleRouter
-from .eventattributemodifier import (EventAttributeModifier, HTTPStatusModifier, XpathEventAttributeModifer, EventAttributeLookupModifier,
+from .eventattributemodifier import (EventAttributeModifier, HTTPStatusModifier, XpathEventAttributeModifier, EventAttributeLookupModifier,
                                      HTTPXpathEventAttributeModifier, JSONEventAttributeModifier, HTTPJSONAttributeModifier, ErrorEventAttributeModifier, 
-                                     XMLErrorEventAttributeModifier)
+                                     XMLErrorEventAttributeModifier, XMLEventAttributeModifier, XMLEventAttributeLookupModifier)
 from .tcp import TCPIn, TCPOut
 from .zeromq import ZMQPush, ZMQPull
 from .xsd import XSD

--- a/compysition/actors/__init__.py
+++ b/compysition/actors/__init__.py
@@ -40,7 +40,8 @@ from .mdpregistrar import MDPBrokerRegistrationService
 from .eventlogger import EventLogger
 from .eventrouter import EventRouter, EventXMLFilter, EventFilter, HTTPMethodEventRouter, EventJSONFilter, EventXMLXpathsFilter, SimpleRouter
 from .eventattributemodifier import (EventAttributeModifier, HTTPStatusModifier, XpathEventAttributeModifer, EventAttributeLookupModifier,
-                                     HTTPXpathEventAttributeModifier, JSONEventAttributeModifier, HTTPJSONAttributeModifier)
+                                     HTTPXpathEventAttributeModifier, JSONEventAttributeModifier, HTTPJSONAttributeModifier, ErrorEventAttributeModifier, 
+                                     XMLErrorEventAttributeModifier)
 from .tcp import TCPIn, TCPOut
 from .zeromq import ZMQPush, ZMQPull
 from .xsd import XSD

--- a/compysition/actors/eventattributemodifier.py
+++ b/compysition/actors/eventattributemodifier.py
@@ -127,11 +127,11 @@ class XpathEventAttributeModifier(EventAttributeModifier):
         if len(xpath_lookup) <= 0:
             value = None
         elif len(xpath_lookup) == 1:
-            value = XpathEventAttributeModifer._parse_result_value(xpath_lookup[0])
+            value = XpathEventAttributeModifier._parse_result_value(xpath_lookup[0])
         else:
             value = []
             for result in xpath_lookup:
-                value.append(XpathEventAttributeModifer._parse_result_value(result))
+                value.append(XpathEventAttributeModifier._parse_result_value(result))
 
         return value
 
@@ -149,7 +149,7 @@ class XpathEventAttributeModifier(EventAttributeModifier):
 
         return value
 
-class HTTPXpathEventAttributeModifier(XpathEventAttributeModifer, HTTPStatusModifier):
+class HTTPXpathEventAttributeModifier(XpathEventAttributeModifier, HTTPStatusModifier):
     pass
 
 class JSONEventAttributeModifier(EventAttributeModifier):
@@ -187,15 +187,20 @@ class XMLEventAttributeModifier(EventAttributeModifier):
         if len(keys) == 0:
             event.set(event_key, value)
         else:
-            current_element = event.get(event_key, None)
+            root_element = event.get(event_key, None)
+            current_element = root_element
 
             try:
+                item = keys.pop(0)
+                if not item == current_element.tag:
+                    raise
                 while True:
-                    item = keys.pop(0)
                     if len(keys) > 0:
+                        item = keys.pop(0)
                         next_step = current_element.get(item, None)
                         if not next_step:
-                            next_step = current_element.SubElement(item)
+                            next_step = etree.Element(item)
+                            current_element.append(next_step)
                         current_element = next_step
                     else:
                         current_element.text = str(value)

--- a/compysition/actors/flowcontroller.py
+++ b/compysition/actors/flowcontroller.py
@@ -33,8 +33,12 @@ class FlowController(Actor):
 
     '''
 
-    def __init__(self, name, *args, **kwargs):
+    def __init__(self, name, trigger_errors=False, *args, **kwargs):
+        self.trigger_errors = trigger_errors
         super(FlowController, self).__init__(name, *args, **kwargs)
 
     def consume(self, event, *args, **kwargs):
-        self.send_event(event)
+        if event.error and self.trigger_errors:
+            self.send_error(event)
+        else:
+            self.send_event(event)

--- a/compysition/actors/httpserver.py
+++ b/compysition/actors/httpserver.py
@@ -179,7 +179,7 @@ class HTTPServer(Actor, Bottle):
 
         return path
 
-    def __init__(self, name, address="0.0.0.0", port=8080, keyfile=None, certfile=None, routes_config=None, *args, **kwargs):
+    def __init__(self, name, address="0.0.0.0", port=8080, keyfile=None, certfile=None, routes_config=None, send_errors=False, *args, **kwargs):
         Actor.__init__(self, name, *args, **kwargs)
         Bottle.__init__(self)
         self.blockdiag_config["shape"] = "cloud"
@@ -188,6 +188,7 @@ class HTTPServer(Actor, Bottle):
         self.keyfile = keyfile
         self.certfile = certfile
         self.responders = {}
+        self.send_errors = send_errors
         routes_config = routes_config or self.DEFAULT_ROUTE
 
         if isinstance(routes_config, str):
@@ -352,7 +353,8 @@ class HTTPServer(Actor, Bottle):
             event_class = event_class or JSONHttpEvent
             event = event_class(environment=environment, service=queue_name, accept=accept, **kwargs)
             event.error = err
-            queue = self.pool.inbound[self.pool.inbound.keys()[0]]
+            if not self.send_error:
+                queue = self.pool.inbound[self.pool.inbound.keys()[0]]
 
         response_queue = Queue()
         self.responders.update({event.event_id: (event_class, response_queue)})

--- a/compysition/errors.py
+++ b/compysition/errors.py
@@ -26,11 +26,12 @@
 
 class CompysitionException(Exception):
 
-    def __init__(self, message="", code=None, **kwargs):
+    def __init__(self, message="", code=None, override=None, **kwargs):
         if not isinstance(message, list):
             message = [message]
 
         self.code = code
+        self.override = override
         self.__dict__.update(kwargs)
         super(CompysitionException, self).__init__(message)
 

--- a/compysition/event.py
+++ b/compysition/event.py
@@ -159,14 +159,32 @@ class Event(object):
         else:
             self._event_id = event_id
 
+    def _list_get(self, obj, key, default):
+        try:
+            return obj[int(key)]
+        except:
+            return default
+
+    def _getattr(self, obj, key, default):
+        try:
+            return getattr(obj, key, default)
+        except:
+            return default
+
+    def _obj_get(self, obj, key, default):
+        try:
+            return obj.get(key, default)
+        except:
+            return default
+
     def lookup(self, path):
         """
-        TODO: Account for list objects in the lookup path and generate multiple results if found
+        Implements the retrieval of a single list index through an integer path entry
         """
         if isinstance(path, str):
             path = [path]
 
-        value = reduce(lambda obj, key: obj.get(key, NullLookupValue()) if isinstance(obj, dict) else getattr(obj, key, NullLookupValue()), [self] + path)
+        value = reduce(lambda obj, key: self._obj_get(obj, key, self._getattr(obj, key, self._list_get(obj, key, NullLookupValue()))), [self] + path)
         if isinstance(value, NullLookupValue):
             value = None
         return value


### PR DESCRIPTION
@fiebiga So, I need error response customization.  Currently, to match vendor format requirements I would have to for go HTTP response codes.  With these changes I can send customized error responses using an HTTP error response format override.